### PR TITLE
Fix single-bit corlib _index typos

### DIFF
--- a/beef-lang.org/content/corlib/_index.md
+++ b/beef-lang.org/content/corlib/_index.md
@@ -16,7 +16,7 @@ The following is a partial list of collection types provided by corlib.
 |Hash set|[System.Collections.HashSet<T>](../doxygen/corlib/html/class_system_1_1_collections_1_1_hash_set.html)|
 |Queue|[System.Collections.Queue<T>](../doxygen/corlib/html/class_system_1_1_collections_1_1_queue.html)|
 
-The following is a parial list of the funtionality provided by corlib. See the complete API documentation for the full list.
+The following is a partial list of the funtionality provided by corlib. See the complete API documentation for the full list.
 
 |Category|Types|
 |-----|------|


### PR DESCRIPTION
Hi Beef, do you think we need to reform a primary README file for the best impression to the others? I will love to do that.