### PR TITLE
Specify minimum version for CMake

### DIFF
--- a/beef-lang.org/content/getting-start/building.md
+++ b/beef-lang.org/content/getting-start/building.md
@@ -22,7 +22,7 @@ The core of the Beef compiler is written in C++, while the IDE and command-line 
 * Microsoft C++ build tools for Visual Studio 2017 or later. You can install just Microsoft Visual C++ Build Tools or the entire Visual Studio suite from https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019.
 * Platform Toolset 141 (VS2017)
 * Windows SDK 10.0.17763.0
-* CMake
+* CMake 3.15
 * Python 2.7
 * Git command line tools
 
@@ -38,7 +38,7 @@ The build results will be in IDE/dist
 
 #### Requirements
 
-* CMake
+* CMake 3.15
 * Python 2.7
 * Git
 

--- a/beef-lang.org/content/getting-start/building.md
+++ b/beef-lang.org/content/getting-start/building.md
@@ -22,7 +22,7 @@ The core of the Beef compiler is written in C++, while the IDE and command-line 
 * Microsoft C++ build tools for Visual Studio 2017 or later. You can install just Microsoft Visual C++ Build Tools or the entire Visual Studio suite from https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019.
 * Platform Toolset 141 (VS2017)
 * Windows SDK 10.0.17763.0
-* CMake 3.15
+* CMake 3.15 or newer
 * Python 2.7
 * Git command line tools
 
@@ -38,7 +38,7 @@ The build results will be in IDE/dist
 
 #### Requirements
 
-* CMake 3.15
+* CMake 3.15 or newer
 * Python 2.7
 * Git
 


### PR DESCRIPTION
Building LLVM currently depends on a CMake feature that was [only introduced in version 3.15](https://cmake.org/cmake/help/latest/release/3.15.html#command-line), but this isn't specified on the documentation, this PR aims to do so.

_The feature in question is the multiple-target support, as seen here: [llvm_build.sh#L21](https://github.com/beefytech/Beef/blob/e61d702da11ad609abbb225d9f2406707218700a/extern/llvm_build.sh#L21)_



