### PR TITLE
struct initializer docs, attrib text move fix

### DIFF
--- a/beef-lang.org/content/language-guide/datatypes/attributes.md
+++ b/beef-lang.org/content/language-guide/datatypes/attributes.md
@@ -23,9 +23,8 @@ weight = 11
 ## Method attributes
 - [AlwaysInclude] - indicates that even if this method would have been skipped by compile-on-demand, it should be included in the build anyway. This can be useful for methods that are meant to be called by reflection.
 - [Checked] - indicates that this method performs runtime checks such as validating arguments (ie: bounds checks)
-- [Commutable] - this attribute creates an additional version of this method where the first two arguments are transposed. This can be useful for creating 
+- [Commutable] - this attribute creates an additional version of this method where the first two arguments are transposed. This can be useful for creating operators whose operations are commutable.
 - [Comptime] - marks a method as being evaluable only at comptime, not at runtime
-operators whose operations are commutable.
 - [DisableChecks] - indicates that calls within this method should call the Unchecked verion of methods when possible (optimization)
 - [DisableObjectAccessChecks] - indicates that object access checks should be disabled within this method (optimization)
 - [Error] - throws a compilation error when the method is called (a more generalized form of [Obsolete])

--- a/beef-lang.org/content/language-guide/datatypes/initialization.md
+++ b/beef-lang.org/content/language-guide/datatypes/initialization.md
@@ -32,7 +32,7 @@ class Student : Person
 
 	public this()
 	{
-		
+
 	}
 
 	public this(int age)
@@ -77,6 +77,35 @@ Value initializers let you assign values to fields and properties of values at c
 ```C#
 /* Construct a Cat, calling the default constructor, and then assign the Age and Name properties */
 var cat = new Cat() { Age = 10, Name = "Fluffy" };
+```
+
+For structs, value initalizers can also be used without calling any constructors or initializer blocks.
+
+```C#
+struct WindowInit
+{
+	public width = 1280;
+	public height;
+
+	this
+	{
+		height = 720;
+	}
+}
+
+/* Default contructor & value initializer: height will be 720, width will be 1280, then set to 1920 */
+var init = WindowInit() { width = 1920 }
+
+/* Is equivalent to */
+var init = WindowInit();
+init.width = 1920;
+
+/* Just value initializer: height will be 0, width will be 0, then set to 1920 */
+var init = WindowInit { width = 1920 }
+
+/* Is equivalent to */
+WindowInit init = default; // Struct is zeroed
+init.width = 1920;
 ```
 
 Value initializers also allow you to add items to collections at creation time. You can provide a list of expressions, which will be passed individually to an applicable `Add` method.


### PR DESCRIPTION
Puts some moved text back into the right sentence in attributes. Also add documentation on struct .{} initializer.