### PR TITLE
Fix reflection docs, document Tets(ShouldFail=true)

### DIFF
--- a/beef-lang.org/content/language-guide/reflection.md
+++ b/beef-lang.org/content/language-guide/reflection.md
@@ -39,6 +39,9 @@ void DynamicCreate()
 	{
 		Console.WriteLine("Successfully created TestClass instance");
 		UseObject(obj);
+
+		/* Objects and values created through reflection are heap-allocated and need to be deleted */
+		delete obj;
 	}
 }
 ```

--- a/beef-lang.org/content/language-guide/reflection.md
+++ b/beef-lang.org/content/language-guide/reflection.md
@@ -10,7 +10,7 @@ Beef supports runtime reflection, which allows enumerating and accessing types, 
 public struct Options
 {
 	[Reflect]
-  public bool mFlag;
+	public bool mFlag;
 }
 
 void Use(ref Options options)

--- a/beef-lang.org/content/testing/_index.md
+++ b/beef-lang.org/content/testing/_index.md
@@ -15,6 +15,19 @@ public static void TestAPI()
 }
 ```
 
+In some cases, tests are expected to fail. The test attribute can be used to mark tests accordingly.
+
+```C#
+[Test(ShouldFail=true)]
+public static void TestBoundsCheck()
+{
+	let array = scope int8[5];
+
+	/* The following will fail a Runtime.Assert in the array indexer, thus failing the test */
+	let num = array[5];
+}
+```
+
 In the Workspace properties, make sure 'Projects' has the 'Test' configuration specified for any projects that you want to run Tests on. By default, the first project specified in the workspace will be configured for testing.
 
 Beef tests are suitable for use in CI systems such as Jenkins, as BeefBuild will emit testing text with timing statistics, and will report success or failure via standard return codes.

--- a/beef-lang.org/content/testing/_index.md
+++ b/beef-lang.org/content/testing/_index.md
@@ -15,7 +15,7 @@ public static void TestAPI()
 }
 ```
 
-In some cases, tests are expected to fail. The test attribute can be used to mark tests accordingly.
+In some cases, tests are expected to fail. The `[Test]` attribute can be used to mark tests accordingly.
 
 ```C#
 [Test(ShouldFail=true)]


### PR DESCRIPTION
Hopefully the additions and fixes to the reflection page help to lessen some of the frequent confusion. I also added a notice of ShouldFail tests to that section. Will probably update this a bit more once the .DefaultConstructor issue is solved and maybe add some Invoke() with args docs too.
Anyway, would be nice if you could also refresh the web page.
Thanks