### PR TITLE
document documentation comments

### DIFF
--- a/beef-lang.org/content/ide/documentation.md
+++ b/beef-lang.org/content/ide/documentation.md
@@ -1,0 +1,35 @@
++++
+title = "Documentation"
++++
+
+## Documentation comments
+
+The IDE allows for documenting types and methods with `///` or `/** */`. Autocomplete suggestions, as well as prompts while calling/using the documented types or functions, will display their documentation.
+
+```C#
+static
+{
+	/// Must be placed directly above the method, including attributes.
+	/// Using multiple lines like this is also fine.
+	[Optimize]
+	public static void DoAThing() {}
+
+	/// Documentation also works for types.
+	struct AA<T>
+	{
+		/**
+		* Multiline comments with two ** at the start.
+		*/
+		void DoAThing() {}
+	}
+
+	/**
+	* If you have a really long explainer here, you may not actually want to show that in autcompletion prompts.
+	* @brief Allows you to select only this line to be shown.
+	* 
+	* @param a This is shown when writing a call to this function and placing parameter "a".
+	* @param b After placing the ',' after the first arg, the documentation for b/the second argument will show up instead.
+	*/
+	public static void DoAnotherThing(int a, int b) {}
+}
+```

--- a/beef-lang.org/content/ide/documentation.md
+++ b/beef-lang.org/content/ide/documentation.md
@@ -28,7 +28,7 @@ static
 	* @brief Allows you to select only this line to be shown.
 	* 
 	* @param a This is shown when writing a call to this function and placing parameter "a".
-	* @param b After placing the ',' after the first arg, the documentation for b/the second argument will show up instead.
+	* @param b For the second argument, the documentation for b (this!) will show up instead.
 	*/
 	public static void DoAnotherThing(int a, int b) {}
 }

--- a/beef-lang.org/content/ide/documentation.md
+++ b/beef-lang.org/content/ide/documentation.md
@@ -4,7 +4,7 @@ title = "Documentation"
 
 ## Documentation comments
 
-The IDE allows for documenting types and methods with `///` or `/** */`. Autocomplete suggestions, as well as prompts while calling/using the documented types or functions, will display their documentation.
+The IDE allows for documenting types and methods with `///` or `/** */` (wich one of these you use doesn't matter). Autocomplete suggestions, as well as prompts while calling/using the documented types or functions, will display their documentation.
 
 ```C#
 static

--- a/beef-lang.org/content/ide/documentation.md
+++ b/beef-lang.org/content/ide/documentation.md
@@ -10,7 +10,7 @@ The IDE allows for documenting types and methods with `///` or `/** */` (wich on
 static
 {
 	/// Must be placed directly above the method, including attributes.
-	/// Using multiple lines like this is also fine.
+	/// Using multiple lines like this is also fine. Both will be recognized.
 	[Optimize]
 	public static void DoAThing() {}
 
@@ -18,7 +18,7 @@ static
 	struct SomeStruct
 	{
 		/**
-		* Multiline comments with two ** at the start.
+		* Multiline comment with two ** at the start works in the same way.
 		*/
 		void PrivateMethod() {}
 	}

--- a/beef-lang.org/content/ide/documentation.md
+++ b/beef-lang.org/content/ide/documentation.md
@@ -15,12 +15,12 @@ static
 	public static void DoAThing() {}
 
 	/// Documentation also works for types.
-	struct AA<T>
+	struct SomeStruct
 	{
 		/**
 		* Multiline comments with two ** at the start.
 		*/
-		void DoAThing() {}
+		void PrivateMethod() {}
 	}
 
 	/**


### PR DESCRIPTION
Adds a file briefly showing how documentation comments work and which special keywords are recognized. I don't know if new files have to be referenced somewhere else? i couldn't find anything about that anyway, so this is just the file and maybe that's fine. I've put this in the IDE folder, as this is more of a tooling thing currently, but am not completely sure about that classification.