### PR TITLE
Add google programmable search

### DIFF
--- a/beef-lang.org/content/search.html
+++ b/beef-lang.org/content/search.html
@@ -1,0 +1,8 @@
++++
+title = "Search Results"
+hidechevrons = "true"
++++
+<div>
+    <script async src="https://cse.google.com/cse.js?cx=73c3f23d9b2e3869d"></script>
+    <div class="gcse-searchresults-only"></div>
+</div>

--- a/beef-lang.org/themes/docdock/layouts/partials/flex/body-aftercontent.html
+++ b/beef-lang.org/themes/docdock/layouts/partials/flex/body-aftercontent.html
@@ -1,7 +1,8 @@
+  {{ if ne .Params.hidechevrons "true" }}
   <div class="chevrons">
     {{ partial "next-prev-page.html" . }}
   </div>
-
+  {{end}}
   </section>
 </article>
 

--- a/beef-lang.org/themes/docdock/layouts/partials/flex/body-beforecontent.html
+++ b/beef-lang.org/themes/docdock/layouts/partials/flex/body-beforecontent.html
@@ -48,19 +48,10 @@
     {{- if not .Site.Params.disableSearch}}
       <div>
         <div class="searchbox">
-          <input data-search-input id="search-by" type="text" placeholder="{{T "Search-placeholder"}}">
+          <form action="/docs/search/" method="GET">
+            <input class="gcse-searchbox" id="search-by" name="q" autocomplete="off" type="text" placeholder="{{T "Search-placeholder"}}" required>
+          </form>
         </div>
-        <script type="text/javascript" src="{{"js/lunr.min.js" | relURL}}"></script>
-        <script type="text/javascript" src="{{"js/auto-complete.js" | relURL}}"></script>
-        <link href="{{"css/auto-complete.css" | relURL}}" rel="stylesheet">
-        <script type="text/javascript">
-          {{ if .Site.IsMultiLingual }}
-              var baseurl = "{{.Site.BaseURL}}{{.Site.LanguagePrefix}}";
-          {{ else }}
-              var baseurl = "{{.Site.BaseURL}}";
-          {{ end }}
-        </script>
-        <script type="text/javascript" src="{{"js/search.js" | relURL}}"></script>
       </div>
     {{- end}}
     


### PR DESCRIPTION
As requested in #32, makes search bar in documentation search the whole site using google.
Image of the results page:
![image](https://user-images.githubusercontent.com/11310500/161196716-8829c76e-7940-41cb-9100-027dd6528a71.png)

Also i would advise to change cx in `search.html` to id beefytech owns, currently it uses my own. Simply go to  [programmablesearchengine.google.com](https://programmablesearchengine.google.com) Create new search engine, use `https://www.beeflang.org/docs/` as site to search, after creating replace the script tag in `search.html` with newly generated one. Then on the `programmablesearchengine` site change "look and feel" of the search engine to results only.