### PR TITLE
change nav chevrons contrast

### DIFF
--- a/beef-lang.org/themes/docdock/static/theme-flex/style.css
+++ b/beef-lang.org/themes/docdock/static/theme-flex/style.css
@@ -259,8 +259,8 @@ section strong {
 
 #navigation {
   margin-top: 3rem;
-  border-top: 1px solid #e6e6e6;
-  border-bottom: 1px solid #e6e6e6;
+  border-top: 1px solid #d4d4d4;
+  border-bottom: 1px solid #d4d4d4;
   padding: 1rem 0rem;
   display: flex;
   flex-direction: row;
@@ -273,7 +273,7 @@ section strong {
     justify-content: flex-start;
     padding-right: 0px;
     align-items: baseline;
-    color: #e5e5e5; }
+    color: #7F7F7F; }
     #navigation a i {
       font-size: 4em;
       margin: auto; }


### PR DESCRIPTION
Change color of the navigation chevrons/text in docs to make them better visible. 
Screenshot for comparison (left is with changes):
![image](https://user-images.githubusercontent.com/11310500/161241723-5620207b-aefd-472d-916e-61099c45a5ed.png)
