### PR TITLE
Update dependencies and remove unecessary section

### DIFF
--- a/beef-lang.org/content/getting-start/building.md
+++ b/beef-lang.org/content/getting-start/building.md
@@ -39,14 +39,12 @@ The build results will be in IDE/dist
 #### Requirements
 
 * CMake 3.15 or newer
-* Python 2.7
+* LLVM-18
 * Git
 
 ### Build Steps
 
 * Build Beef with bin/build.sh
-
-This will build dependencies such as LLVM, which can take quite some time.
 
 The build results will be in IDE/dist
 

--- a/beef-lang.org/content/language-guide/pattern.md
+++ b/beef-lang.org/content/language-guide/pattern.md
@@ -111,6 +111,3 @@ void Enlarge(ref Shape shape)
 }
 
 ```
-
-
-### Value matching


### PR DESCRIPTION
This fixes:
#16 
Also #20  is already done and you can probably close it.

In additon to that it removes the listed python dependency since that was only used for building llvm and adds llvm-18 as a dependency to the linux section of the build from source page.