### PR TITLE
Issue_43 : Broken links in docs/language-guide/memory

### DIFF
--- a/beef-lang.org/content/language-guide/memory.md
+++ b/beef-lang.org/content/language-guide/memory.md
@@ -112,7 +112,7 @@ void ReadString(int reserveLen)
 
 Note the use of `delete:null` in the case above. The `ScopedAlloc!` call will release the actual memory that is allocated, but it will not call the String destructor. If `UseString` were to append additional data to `str` that extends beyond `reserveLen`, a heap allocation would occur which would need to be freed by the `String` destructor. The `delete:null` allows you to perform that destruction without requesting the release of any memory.
 
-Many corlib classes such as [System.String](../doxygen/corlib/html/class_system_1_1_string.html) and [System.Collections.List<T>](../doxygen/corlib/html/class_system_1_1_collections_1_1_list.html) need to dynamically allocate memory. By convention, these classes allocate from the global allocator, and they support custom allocator for their internal allocations through virtual method overrides such as `String.Alloc` and `String.Free`.
+Many corlib classes such as [System.String](../../doxygen/corlib/html/class_system_1_1_string.html) and [System.Collections.List<T>](../../doxygen/corlib/html/class_system_1_1_collections_1_1_list.html) need to dynamically allocate memory. By convention, these classes allocate from the global allocator, and they support custom allocator for their internal allocations through virtual method overrides such as `String.Alloc` and `String.Free`.
 
 ### Global allocator
 The global allocator is selected on a per-workspace basis. By default, the CRT malloc/free allocators are used, but any C-style global allocator can be used, such as TCMalloc or JEMalloc. In addition, Beef contains a special debug allocator which enables features such as real-time leak checking and hot compilation.


### PR DESCRIPTION
Fixed the links to System.String and System.Collections.List in the page docs/language-guide/memory/index.html in the sentence "Many corlib classes such as System.String and System.Collections.List need to dynamically allocate memory"